### PR TITLE
Remove namespace from gnome2.pango

### DIFF
--- a/talon.nix
+++ b/talon.nix
@@ -112,7 +112,7 @@ buildFHSEnv {
     gdk-pixbuf
     cairo
     libdrm
-    gnome2.pango
+    pango
     gdbm
     atk
     wayland


### PR DESCRIPTION
The alias for `gnome2.pango` was removed.

https://github.com/NixOS/nixpkgs/commit/dab3496fa266e098d512accda47f2a80de40be73